### PR TITLE
bug fix

### DIFF
--- a/DKHelper/DKHelper.m
+++ b/DKHelper/DKHelper.m
@@ -69,7 +69,14 @@ NSNumber *  GET_NUMBER(NSDictionary *dict, id key) {
 }
 
 NSDate *    GET_DATE(NSDictionary *dict, id key) {
-    return (VALID(dict, key) ? [NSDate dateFromISOString:dict[key]] : nil);
+    if (VALID(dict, key)) {
+        if ([dict[key] isKindOfClass:[NSDate class]]) {
+            return dict[key];
+        } else if ([dict[key] isKindOfClass:[NSString class]]) {
+            return [NSDate dateFromISOString:dict[key]];
+        }
+    }
+    return nil;
 }
 
 NSString *  GET_STRING(NSDictionary *dict, id key) {


### PR DESCRIPTION
Hi,

there was a crash in this method. By passing a real NSDate like below:

```
NSDate *date = [[NSDate alloc] init];
NSMutableDictionary *dict = [[NSMutableDictionary alloc] init];
[dict setValue:date forKey:@"date"];

GET_DATE(dict, @"date"); // crash
```

A fix for this was to not pass the date, but the iso-Value:

```
[dict setValue:date.ISO8601StringValue forKey:@"date"];
```

with this "fix", both methods will work fine.