### PR TITLE
NSDate testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Enhancements
 
+- NSDate: fix minor Timezone Bug in `currentDayDate`
 - Improve swift compatibility for all classes and functions!
 - The test project is now coded in Swift.
 - NSString: add `randomString` function.

--- a/DKHelper/NSDate+DKHelper.m
+++ b/DKHelper/NSDate+DKHelper.m
@@ -170,7 +170,7 @@
 	NSDateComponents* dateComponents = [gregorian components:unitFlags fromDate:[NSDate date]];
 	dateComponents.timeZone = [NSTimeZone timeZoneForSecondsFromGMT:0];
 	[dateComponents setMinute:0];
-	[dateComponents setSecond:[[NSTimeZone defaultTimeZone] secondsFromGMT]];
+	[dateComponents setSecond:0];
 	[dateComponents setHour:0];
 	return [gregorian dateFromComponents:dateComponents];
 }

--- a/Example/DKHelper.xcodeproj/project.pbxproj
+++ b/Example/DKHelper.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		281327011C1197EC00614EDB /* NSDateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 281327001C1197EC00614EDB /* NSDateTests.swift */; };
 		752363FA1C0F0BE300229994 /* NSPredicateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 752363F81C0F0BE300229994 /* NSPredicateTests.swift */; };
 		752BB6D71BE8D4A6001B8A25 /* UIColorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 752BB6D61BE8D4A6001B8A25 /* UIColorTests.swift */; };
 		753298641BE8C7BF00FD8252 /* CGRect+DKHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 753298411BE8C7BF00FD8252 /* CGRect+DKHelper.m */; };
@@ -84,6 +85,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		281327001C1197EC00614EDB /* NSDateTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSDateTests.swift; sourceTree = "<group>"; };
 		752363F81C0F0BE300229994 /* NSPredicateTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSPredicateTests.swift; sourceTree = "<group>"; };
 		752BB6D61BE8D4A6001B8A25 /* UIColorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIColorTests.swift; sourceTree = "<group>"; };
 		753298401BE8C7BF00FD8252 /* CGRect+DKHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "CGRect+DKHelper.h"; path = "../DKHelper/CGRect+DKHelper.h"; sourceTree = "<group>"; };
@@ -294,6 +296,7 @@
 				75B8D49D1BF10541008930B1 /* UIImageViewTests.swift */,
 				75B8D49B1BF0F59E008930B1 /* UIScreenTests.swift */,
 				759A46801BEBD14400FFAB39 /* UIViewTests.swift */,
+				281327001C1197EC00614EDB /* NSDateTests.swift */,
 				75D1721B1BE8C62500AE890C /* Info.plist */,
 			);
 			path = DKHelperTests;
@@ -464,6 +467,7 @@
 				75D011F31BEB945B003C6E9A /* NSNumberTests.swift in Sources */,
 				753298711BE8C7BF00FD8252 /* NSDate+DKHelper.m in Sources */,
 				7532986B1BE8C7BF00FD8252 /* DKRegex.m in Sources */,
+				281327011C1197EC00614EDB /* NSDateTests.swift in Sources */,
 				75B8D49C1BF0F59E008930B1 /* UIScreenTests.swift in Sources */,
 				752BB6D71BE8D4A6001B8A25 /* UIColorTests.swift in Sources */,
 				753298751BE8C7BF00FD8252 /* NSObject+DKHelper.m in Sources */,

--- a/Example/DKHelperTests/NSDateTests.swift
+++ b/Example/DKHelperTests/NSDateTests.swift
@@ -142,3 +142,40 @@ extension NSDateTests {
 		}
 	}
 }
+
+// MARK: - getting Date Components
+
+extension NSDateTests {
+
+	func testShouldReturnDatesComponents() {
+		let date = NSDate(timeIntervalSince1970: 0)
+		XCTAssertEqual(date.year(), 1970)
+		XCTAssertEqual(date.day(), 1)
+		XCTAssertEqual(date.month(), 1)
+		XCTAssertEqual(date.hour(), 1, "expect Time Zone GMT+1")
+		XCTAssertEqual(date.minute(), 0)
+		XCTAssertEqual(date.second(), 0)
+	}
+
+	func testShouldReturnTodaysMidnightDate() {
+		let date = today?.midnightDate()
+		XCTAssertNotNil(date)
+		XCTAssertEqual(date?.year(), today?.year())
+		XCTAssertEqual(date?.day(), today?.day())
+		XCTAssertEqual(date?.month(), today?.month())
+		XCTAssertEqual(date?.hour(), 1, "expect Time Zone GMT+1")
+		XCTAssertEqual(date?.minute(), 0)
+		XCTAssertEqual(date?.second(), 0)
+	}
+
+	func testShouldReturnTodaysDayDate() {
+		let date = NSDate.currentDayDate()
+		XCTAssertNotNil(date)
+		XCTAssertEqual(date?.year(), today?.year())
+		XCTAssertEqual(date?.day(), today?.day())
+		XCTAssertEqual(date?.month(), today?.month())
+		XCTAssertEqual(date?.hour(), 1, "expect Time Zone GMT+1")
+		XCTAssertEqual(date?.minute(), 0)
+		XCTAssertEqual(date?.second(), 0)
+	}
+}

--- a/Example/DKHelperTests/NSDateTests.swift
+++ b/Example/DKHelperTests/NSDateTests.swift
@@ -6,4 +6,88 @@
 //  Copyright © 2015 Kevin Delord. All rights reserved.
 //
 
-import Foundation
+import XCTest
+@testable import DKHelper
+
+class NSDateTests	: XCTestCase {
+
+	var today		: NSDate?
+
+}
+
+// MARK: - Is date older or equal
+
+extension NSDateTests {
+
+	override func setUp() {
+		super.setUp()
+		self.today = NSDate()
+	}
+
+	func testShouldCheckIfTodayIsEqualToToday() {
+		if let today = self.today {
+			let date = NSDateComponents()
+			date.day = 0
+			date.month = 0
+			date.year = 0
+			let result = today.isOlderOrEqualThan(date)
+			XCTAssertTrue(result)
+		} else {
+			XCTFail()
+		}
+	}
+
+	func testShouldCheckIfTodayIsNotOlderThenEarlierYear() {
+		if let today = self.today {
+			let result = today.isOlderOrEqualThan(10, months: 0, days: 0, hours: 0, minutes: 0, seconds: 0)
+			XCTAssertFalse(result)
+		} else {
+			XCTFail()
+		}
+	}
+
+	func testShouldCheckIfTodayIsOlderThenLaterYear() {
+		if let today = self.today {
+			let result = today.isOlderOrEqualThanYearInterval(-2)
+			XCTAssertTrue(result)
+		} else {
+			XCTFail()
+		}
+	}
+
+	func testShouldCheckIfTodayIsOlderThenLaterMonth() {
+		if let today = self.today {
+			let result = today.isOlderOrEqualThanMonthInterval(-12)
+			XCTAssertTrue(result)
+		} else {
+			XCTFail()
+		}
+	}
+
+	func testShouldCheckIfTodayIsNotOlderThenEarlierDay() {
+		if let today = self.today {
+			let result = today.isOlderOrEqualThanDayInterval(366)
+			XCTAssertFalse(result)
+		} else {
+			XCTFail()
+		}
+	}
+
+	func testShouldCheckIfTodayIsNotOlderThenEarlierMinute() {
+		if let today = self.today {
+			let result = today.isOlderOrEqualThanDayInterval(1)
+			XCTAssertFalse(result)
+		} else {
+			XCTFail()
+		}
+	}
+
+	func testShouldCheckIfTodayIsOlderThenLaterSecond() {
+		if let today = self.today {
+			let result = today.isOlderOrEqualThanSecondInterval(-1)
+			XCTAssertTrue(result)
+		} else {
+			XCTFail()
+		}
+	}
+}

--- a/Example/DKHelperTests/NSDateTests.swift
+++ b/Example/DKHelperTests/NSDateTests.swift
@@ -191,8 +191,8 @@ extension NSDateTests {
 		XCTAssertNotNil(date)
 		XCTAssertNotNil(dayName)
 		XCTAssertNotNil(monthName)
-		XCTAssertEqual(dayName, "Freitag", "expect english localization")
-		XCTAssertEqual(monthName, "Dezember", "expect english localization")
+		XCTAssertEqual(dayName, "Freitag", "expect german localization")
+		XCTAssertEqual(monthName, "Dezember", "expect german localization")
 	}
 
 	func testShouldReturnValidAndCorrectDateDisplayStrings() {
@@ -204,8 +204,77 @@ extension NSDateTests {
 		XCTAssertNotNil(fullDisplayString)
 		XCTAssertNotNil(hourDisplayString)
 		XCTAssertNotNil(displayString)
-		XCTAssertEqual(fullDisplayString, "4. Dezember 2015 um 15:27")
-		XCTAssertEqual(hourDisplayString, "15:27")
-		XCTAssertEqual(displayString, "04.12.2015")
+		XCTAssertEqual(fullDisplayString, "4. Dezember 2015 um 15:27", "expect german localization")
+		XCTAssertEqual(hourDisplayString, "15:27", "expect german localization")
+		XCTAssertEqual(displayString, "04.12.2015", "expect german localization")
+	}
+}
+
+// MARK: - Date by adding Interval
+
+extension NSDateTests {
+
+	func testShouldReturnDateByAddingInterval() {
+		let date 			= NSDate(fromString: "04.12.2015 - 14:27:11", format: "dd.MM.yyyy - HH:mm:ss")
+		let possibleResult 	= NSDate(fromString: "04.12.2017 - 20:00:00", format: "dd.MM.yyyy - HH:mm:ss")
+		let result = date?.dateByAddingIntervalsWithYear(1, months: 12, days: 0, hours: 5, minutes: 32, seconds: 49)
+
+		XCTAssertNotNil(date)
+		XCTAssertNotNil(possibleResult)
+		XCTAssertNotNil(result)
+		XCTAssertEqual(possibleResult?.year(), result?.year())
+		XCTAssertEqual(possibleResult?.month(), result?.month())
+		XCTAssertEqual(possibleResult?.day(), result?.day())
+		XCTAssertEqual(possibleResult?.hour(), result?.hour())
+		XCTAssertEqual(possibleResult?.second(), result?.minute())
+		XCTAssertEqual(possibleResult?.second(), result?.second())
+	}
+
+	func testShouldReturnValidDateByAddingYear() {
+		if let date = today?.dateByAddingYearInterval(1) {
+			XCTAssertEqual(today?.laterDate(date), date)
+		} else {
+			XCTFail()
+		}
+	}
+
+	func testShouldReturnValidDateByAddingMonth() {
+		if let date = today?.dateByAddingMonthInterval(1) {
+			XCTAssertEqual(today?.laterDate(date), date)
+		} else {
+			XCTFail()
+		}
+	}
+
+	func testShouldReturnValidDateByAddingDay() {
+		if let date = today?.dateByAddingDayInterval(1) {
+			XCTAssertEqual(today?.laterDate(date), date)
+		} else {
+			XCTFail()
+		}
+	}
+
+	func testShouldReturnValidDateByAddingHour() {
+		if let date = today?.dateByAddingHourInterval(1) {
+			XCTAssertEqual(today?.laterDate(date), date)
+		} else {
+			XCTFail()
+		}
+	}
+
+	func testShouldReturnValidDateByAddingMinute() {
+		if let date = today?.dateByAddingMinuteInterval(1) {
+			XCTAssertEqual(today?.laterDate(date), date)
+		} else {
+			XCTFail()
+		}
+	}
+
+	func testShouldReturnValidDateByAddingSecond() {
+		if let date = today?.dateByAddingSecondInterval(1) {
+			XCTAssertEqual(today?.laterDate(date), date)
+		} else {
+			XCTFail()
+		}
 	}
 }

--- a/Example/DKHelperTests/NSDateTests.swift
+++ b/Example/DKHelperTests/NSDateTests.swift
@@ -91,3 +91,54 @@ extension NSDateTests {
 		}
 	}
 }
+
+// MARK: - Create date from a String
+
+extension NSDateTests {
+
+	func testShouldReturnValidAndCorrectDate() {
+		let date = NSDate(fromString: "Dec 24, 1992", style: .MediumStyle)
+		XCTAssertNotNil(date)
+		XCTAssertEqual(date?.year(), 1992)
+		XCTAssertEqual(date?.day(), 24)
+		XCTAssertEqual(date?.month(), 12)
+	}
+
+	func testShouldReturnNilDate() {
+		let date = NSDate(fromString: "Dec 24, 1992", style: .FullStyle)
+		XCTAssertNil(date)
+	}
+
+	func testShouldReturnValidAndCorrectDateWithStringFormat() {
+		let date = NSDate(fromString: "24.12.1992", format: "dd.MM.yyyy")
+		XCTAssertNotNil(date)
+		XCTAssertEqual(date?.year(), 1992)
+		XCTAssertEqual(date?.day(), 24)
+		XCTAssertEqual(date?.month(), 12)
+	}
+
+	func testShouldReturnValidTodayDate() {
+		if let today = self.today {
+			let date = NSDate(fromISOString: today.ISO8601StringValue())
+			XCTAssertNotNil(date)
+			XCTAssertEqual(date?.year(), today.year())
+			XCTAssertEqual(date?.day(), today.day())
+			XCTAssertEqual(date?.month(), today.month())
+			XCTAssertEqual(date?.hour(), today.hour())
+			XCTAssertEqual(date?.minute(), today.minute())
+			XCTAssertEqual(date?.second(), today.second())
+		} else {
+			XCTFail()
+		}
+	}
+
+	func testReturnValidStringValueOfTodayDate() {
+		if let today = self.today {
+			let value = today.stringValue()
+			XCTAssertNotNil(value)
+			XCTAssertTrue(value.characters.count > 0)
+		} else {
+			XCTFail()
+		}
+	}
+}

--- a/Example/DKHelperTests/NSDateTests.swift
+++ b/Example/DKHelperTests/NSDateTests.swift
@@ -1,0 +1,9 @@
+//
+//  NSDateTests.swift
+//  DKHelper
+//
+//  Created by Konstantin Deichmann on 04.12.15.
+//  Copyright © 2015 Kevin Delord. All rights reserved.
+//
+
+import Foundation

--- a/Example/DKHelperTests/NSDateTests.swift
+++ b/Example/DKHelperTests/NSDateTests.swift
@@ -97,7 +97,7 @@ extension NSDateTests {
 extension NSDateTests {
 
 	func testShouldReturnValidAndCorrectDate() {
-		let date = NSDate(fromString: "Dec 24, 1992", style: .MediumStyle)
+		let date = NSDate(fromString: "24.12.1992", style: .MediumStyle)
 		XCTAssertNotNil(date)
 		XCTAssertEqual(date?.year(), 1992)
 		XCTAssertEqual(date?.day(), 24)
@@ -143,7 +143,7 @@ extension NSDateTests {
 	}
 }
 
-// MARK: - getting Date Components
+// MARK: - Getting Date Components
 
 extension NSDateTests {
 
@@ -177,5 +177,35 @@ extension NSDateTests {
 		XCTAssertEqual(date?.hour(), 1, "expect Time Zone GMT+1")
 		XCTAssertEqual(date?.minute(), 0)
 		XCTAssertEqual(date?.second(), 0)
+	}
+}
+
+// MARK: - Date dispaly Strings
+
+extension NSDateTests {
+
+	func testShouldReturnValidAndCorrectDateComponentNaming() {
+		let date = NSDate(fromString: "04.12.2015", format: "dd.MM.yyyy")
+		let dayName = date?.dayName()
+		let monthName = date?.monthName()
+		XCTAssertNotNil(date)
+		XCTAssertNotNil(dayName)
+		XCTAssertNotNil(monthName)
+		XCTAssertEqual(dayName, "Freitag", "expect english localization")
+		XCTAssertEqual(monthName, "Dezember", "expect english localization")
+	}
+
+	func testShouldReturnValidAndCorrectDateDisplayStrings() {
+		let date = NSDate(fromString: "04.12.2015 - 14:27:11", format: "dd.MM.yyyy - HH:mm:ss")
+		let fullDisplayString = date?.fullDisplayTime()
+		let hourDisplayString = date?.hourDisplayTime()
+		let displayString = date?.displayableString()
+		XCTAssertNotNil(date)
+		XCTAssertNotNil(fullDisplayString)
+		XCTAssertNotNil(hourDisplayString)
+		XCTAssertNotNil(displayString)
+		XCTAssertEqual(fullDisplayString, "4. Dezember 2015 um 15:27")
+		XCTAssertEqual(hourDisplayString, "15:27")
+		XCTAssertEqual(displayString, "04.12.2015")
 	}
 }

--- a/Example/DKHelperTests/NSDateTests.swift
+++ b/Example/DKHelperTests/NSDateTests.swift
@@ -73,6 +73,15 @@ extension NSDateTests {
 		}
 	}
 
+	func testShouldCheckIfTodayIsNotOlderThenEarlierHour() {
+		if let today = self.today {
+			let result = today.isOlderOrEqualThanHourInterval(366)
+			XCTAssertFalse(result)
+		} else {
+			XCTFail()
+		}
+	}
+
 	func testShouldCheckIfTodayIsNotOlderThenEarlierMinute() {
 		if let today = self.today {
 			let result = today.isOlderOrEqualThanDayInterval(1)

--- a/Example/DKHelperTests/NSDateTests.swift
+++ b/Example/DKHelperTests/NSDateTests.swift
@@ -278,3 +278,15 @@ extension NSDateTests {
 		}
 	}
 }
+
+// MARK: - ISO Format
+
+extension NSDateTests {
+
+	func testShouldReturnValidAndCorrectISOStringFromDate() {
+		let date = NSDate(fromString: "04.12.2015 - 14:27:11", format: "dd.MM.yyyy - HH:mm:ss")
+		let isoString = date?.ISO8601StringValue()
+		XCTAssertNotNil(isoString)
+		XCTAssertEqual(isoString, "2015-12-04T14:27:11Z")
+	}
+}

--- a/Example/DKHelperTests/NSDateTests.swift
+++ b/Example/DKHelperTests/NSDateTests.swift
@@ -24,7 +24,7 @@ extension NSDateTests {
 		self.today = NSDate()
 	}
 
-	func testShouldCheckIfTodayIsEqualToToday() {
+	func test_ShouldCheckIfTodayIsEqualToToday() {
 		if let today = self.today {
 			let date = NSDateComponents()
 			date.day = 0
@@ -37,7 +37,7 @@ extension NSDateTests {
 		}
 	}
 
-	func testShouldCheckIfTodayIsNotOlderThenEarlierYear() {
+	func test_ShouldCheckIfTodayIsNotOlderThenEarlierYear() {
 		if let today = self.today {
 			let result = today.isOlderOrEqualThan(10, months: 0, days: 0, hours: 0, minutes: 0, seconds: 0)
 			XCTAssertFalse(result)
@@ -46,7 +46,7 @@ extension NSDateTests {
 		}
 	}
 
-	func testShouldCheckIfTodayIsOlderThenLaterYear() {
+	func test_ShouldCheckIfTodayIsOlderThenLaterYear() {
 		if let today = self.today {
 			let result = today.isOlderOrEqualThanYearInterval(-2)
 			XCTAssertTrue(result)
@@ -55,7 +55,7 @@ extension NSDateTests {
 		}
 	}
 
-	func testShouldCheckIfTodayIsOlderThenLaterMonth() {
+	func test_ShouldCheckIfTodayIsOlderThenLaterMonth() {
 		if let today = self.today {
 			let result = today.isOlderOrEqualThanMonthInterval(-12)
 			XCTAssertTrue(result)
@@ -64,7 +64,7 @@ extension NSDateTests {
 		}
 	}
 
-	func testShouldCheckIfTodayIsNotOlderThenEarlierDay() {
+	func test_ShouldCheckIfTodayIsNotOlderThenEarlierDay() {
 		if let today = self.today {
 			let result = today.isOlderOrEqualThanDayInterval(366)
 			XCTAssertFalse(result)
@@ -73,7 +73,7 @@ extension NSDateTests {
 		}
 	}
 
-	func testShouldCheckIfTodayIsNotOlderThenEarlierHour() {
+	func test_ShouldCheckIfTodayIsNotOlderThenEarlierHour() {
 		if let today = self.today {
 			let result = today.isOlderOrEqualThanHourInterval(366)
 			XCTAssertFalse(result)
@@ -82,7 +82,7 @@ extension NSDateTests {
 		}
 	}
 
-	func testShouldCheckIfTodayIsNotOlderThenEarlierMinute() {
+	func test_ShouldCheckIfTodayIsNotOlderThenEarlierMinute() {
 		if let today = self.today {
 			let result = today.isOlderOrEqualThanDayInterval(1)
 			XCTAssertFalse(result)
@@ -91,7 +91,7 @@ extension NSDateTests {
 		}
 	}
 
-	func testShouldCheckIfTodayIsOlderThenLaterSecond() {
+	func test_ShouldCheckIfTodayIsOlderThenLaterSecond() {
 		if let today = self.today {
 			let result = today.isOlderOrEqualThanSecondInterval(-1)
 			XCTAssertTrue(result)
@@ -105,7 +105,7 @@ extension NSDateTests {
 
 extension NSDateTests {
 
-	func testShouldReturnValidAndCorrectDate() {
+	func test_ShouldReturnValidAndCorrectDate() {
 		let date = NSDate(fromString: "24.12.1992", style: .MediumStyle)
 		XCTAssertNotNil(date)
 		XCTAssertEqual(date?.year(), 1992)
@@ -113,12 +113,21 @@ extension NSDateTests {
 		XCTAssertEqual(date?.month(), 12)
 	}
 
-	func testShouldReturnNilDate() {
+	func test_ShouldReturnInValidDate() {
+		let date = NSDate(fromString: "Dec 24, 1992", style: .MediumStyle)
+		let dateByFormat = NSDate(fromString: "24.12.1992", format: "yyyy.MM.dd")
+		let dateByString = NSDate(fromString: "ab.cd.efgh", format: "dd.MM.yyyy")
+		XCTAssertNil(date, "expect German Region")
+		XCTAssertNil(dateByFormat)
+		XCTAssertNil(dateByString)
+	}
+
+	func test_ShouldReturnNilDate() {
 		let date = NSDate(fromString: "Dec 24, 1992", style: .FullStyle)
 		XCTAssertNil(date)
 	}
 
-	func testShouldReturnValidAndCorrectDateWithStringFormat() {
+	func test_ShouldReturnValidAndCorrectDateWithStringFormat() {
 		let date = NSDate(fromString: "24.12.1992", format: "dd.MM.yyyy")
 		XCTAssertNotNil(date)
 		XCTAssertEqual(date?.year(), 1992)
@@ -126,7 +135,7 @@ extension NSDateTests {
 		XCTAssertEqual(date?.month(), 12)
 	}
 
-	func testShouldReturnValidTodayDate() {
+	func test_ShouldReturnValidTodayDate() {
 		if let today = self.today {
 			let date = NSDate(fromISOString: today.ISO8601StringValue())
 			XCTAssertNotNil(date)
@@ -156,7 +165,7 @@ extension NSDateTests {
 
 extension NSDateTests {
 
-	func testShouldReturnDatesComponents() {
+	func test_ShouldReturnDatesComponents() {
 		let date = NSDate(timeIntervalSince1970: 0)
 		XCTAssertEqual(date.year(), 1970)
 		XCTAssertEqual(date.day(), 1)
@@ -166,7 +175,7 @@ extension NSDateTests {
 		XCTAssertEqual(date.second(), 0)
 	}
 
-	func testShouldReturnTodaysMidnightDate() {
+	func test_ShouldReturnTodaysMidnightDate() {
 		let date = today?.midnightDate()
 		XCTAssertNotNil(date)
 		XCTAssertEqual(date?.year(), today?.year())
@@ -177,7 +186,7 @@ extension NSDateTests {
 		XCTAssertEqual(date?.second(), 0)
 	}
 
-	func testShouldReturnTodaysDayDate() {
+	func test_ShouldReturnTodaysDayDate() {
 		let date = NSDate.currentDayDate()
 		XCTAssertNotNil(date)
 		XCTAssertEqual(date?.year(), today?.year())
@@ -193,7 +202,7 @@ extension NSDateTests {
 
 extension NSDateTests {
 
-	func testShouldReturnValidAndCorrectDateComponentNaming() {
+	func test_ShouldReturnValidAndCorrectDateComponentNaming() {
 		let date = NSDate(fromString: "04.12.2015", format: "dd.MM.yyyy")
 		let dayName = date?.dayName()
 		let monthName = date?.monthName()
@@ -204,7 +213,7 @@ extension NSDateTests {
 		XCTAssertEqual(monthName, "Dezember", "expect german localization")
 	}
 
-	func testShouldReturnValidAndCorrectDateDisplayStrings() {
+	func test_ShouldReturnValidAndCorrectDateDisplayStrings() {
 		let date = NSDate(fromString: "04.12.2015 - 14:27:11", format: "dd.MM.yyyy - HH:mm:ss")
 		let fullDisplayString = date?.fullDisplayTime()
 		let hourDisplayString = date?.hourDisplayTime()
@@ -223,7 +232,7 @@ extension NSDateTests {
 
 extension NSDateTests {
 
-	func testShouldReturnDateByAddingInterval() {
+	func test_ShouldReturnDateByAddingInterval() {
 		let date 			= NSDate(fromString: "04.12.2015 - 14:27:11", format: "dd.MM.yyyy - HH:mm:ss")
 		let possibleResult 	= NSDate(fromString: "04.12.2017 - 20:00:00", format: "dd.MM.yyyy - HH:mm:ss")
 		let result = date?.dateByAddingIntervalsWithYear(1, months: 12, days: 0, hours: 5, minutes: 32, seconds: 49)
@@ -239,49 +248,67 @@ extension NSDateTests {
 		XCTAssertEqual(possibleResult?.second(), result?.second())
 	}
 
-	func testShouldReturnValidDateByAddingYear() {
-		if let date = today?.dateByAddingYearInterval(1) {
-			XCTAssertEqual(today?.laterDate(date), date)
+	func test_ShouldReturnValidDateByAddingYear() {
+		if let
+			today = self.today,
+			date = today.dateByAddingYearInterval(1) {
+				XCTAssertEqual(today.laterDate(date), date)
+				XCTAssertEqual(abs(today.year() - date.year()), 1)
 		} else {
 			XCTFail()
 		}
 	}
 
-	func testShouldReturnValidDateByAddingMonth() {
-		if let date = today?.dateByAddingMonthInterval(1) {
-			XCTAssertEqual(today?.laterDate(date), date)
+	func test_ShouldReturnValidDateByAddingMonth() {
+		if let
+			today = NSDate(fromString: "04.11.2015 - 14:27:11", format: "dd.MM.yyyy - HH:mm:ss"),
+			date = today.dateByAddingMonthInterval(1) {
+				XCTAssertEqual(today.laterDate(date), date)
+				XCTAssertEqual(abs(today.month() - date.month()), 1)
 		} else {
 			XCTFail()
 		}
 	}
 
-	func testShouldReturnValidDateByAddingDay() {
-		if let date = today?.dateByAddingDayInterval(1) {
-			XCTAssertEqual(today?.laterDate(date), date)
+	func test_ShouldReturnValidDateByAddingDay() {
+		if let
+			today = NSDate(fromString: "04.11.2015 - 14:27:11", format: "dd.MM.yyyy - HH:mm:ss"),
+			date = today.dateByAddingDayInterval(-1) {
+				XCTAssertEqual(today.earlierDate(date), date)
+				XCTAssertEqual(abs(today.day() - date.day()), 1)
 		} else {
 			XCTFail()
 		}
 	}
 
-	func testShouldReturnValidDateByAddingHour() {
-		if let date = today?.dateByAddingHourInterval(1) {
-			XCTAssertEqual(today?.laterDate(date), date)
+	func test_ShouldReturnValidDateByAddingHour() {
+		if let
+			today = NSDate(fromString: "04.11.2015 - 14:27:11", format: "dd.MM.yyyy - HH:mm:ss"),
+			date = today.dateByAddingHourInterval(24) {
+				XCTAssertEqual(today.laterDate(date), date)
+				XCTAssertEqual(abs(today.hour() - date.hour()), 0)
+				XCTAssertEqual(abs(today.day() - date.day()), 1)
 		} else {
 			XCTFail()
 		}
 	}
 
-	func testShouldReturnValidDateByAddingMinute() {
-		if let date = today?.dateByAddingMinuteInterval(1) {
-			XCTAssertEqual(today?.laterDate(date), date)
+	func test_ShouldReturnValidDateByAddingMinute() {
+		if let
+			today = NSDate(fromString: "04.11.2015 - 14:27:11", format: "dd.MM.yyyy - HH:mm:ss"),
+			date = today.dateByAddingMinuteInterval(-1) {
+				XCTAssertEqual(today.earlierDate(date), date)
+				XCTAssertEqual(abs(today.minute() - date.minute()), 1)
 		} else {
 			XCTFail()
 		}
 	}
 
-	func testShouldReturnValidDateByAddingSecond() {
-		if let date = today?.dateByAddingSecondInterval(1) {
-			XCTAssertEqual(today?.laterDate(date), date)
+	func test_ShouldReturnValidDateByAddingSecond() {
+		if let
+			today = NSDate(fromString: "04.11.2015 - 14:27:11", format: "dd.MM.yyyy - HH:mm:ss"),
+			date = today.dateByAddingSecondInterval(1) {
+				XCTAssertEqual(today.laterDate(date), date)
 		} else {
 			XCTFail()
 		}
@@ -292,7 +319,7 @@ extension NSDateTests {
 
 extension NSDateTests {
 
-	func testShouldReturnValidAndCorrectISOStringFromDate() {
+	func test_ShouldReturnValidAndCorrectISOStringFromDate() {
 		let date = NSDate(fromString: "04.12.2015 - 14:27:11", format: "dd.MM.yyyy - HH:mm:ss")
 		let isoString = date?.ISO8601StringValue()
 		XCTAssertNotNil(isoString)


### PR DESCRIPTION
##### Untested functions in `NSDate+DKHelper`

```Objective-c
- (void)logCurrentDateWithDateStyleAndAllTimeStyle:(NSDateFormatterStyle)dateStyle;
- (void)logAllFormats;

+ (NSString * _Nonnull)gregorianCalendarIdentifier DEPRECATED_MSG_ATTRIBUTE("use NSCalendarIdentifierGregorian");
```
Because they are deprecated or just not testable (`void` function)


##### 1 Bugfix was made:
`currentDayDate ` was setting the current settings (for GMT+1 the seconds were set to 1h), but seconds should be always 0.

