### PR TITLE
Print a warning to the console if a localized string doesn't exist.

### DIFF
--- a/DKHelper/DKHelper.xcodeproj/project.pbxproj
+++ b/DKHelper/DKHelper.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3AF99C301D65C09600B42C16 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 3AF99C2F1D65C09600B42C16 /* Localizable.strings */; };
 		757800121CCE510A000CD33F /* CGRect+DKHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 7578FFEE1CCE510A000CD33F /* CGRect+DKHelper.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		757800131CCE510A000CD33F /* CGRect+DKHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 7578FFEF1CCE510A000CD33F /* CGRect+DKHelper.m */; };
 		757800141CCE510A000CD33F /* CGRect+DKHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 7578FFEF1CCE510A000CD33F /* CGRect+DKHelper.m */; };
@@ -95,6 +96,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		3AF99C2F1D65C09600B42C16 /* Localizable.strings */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; path = Localizable.strings; sourceTree = "<group>"; };
 		757800001CCE510A000CD33F /* NSOperationQueue+DKHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSOperationQueue+DKHelper.h"; sourceTree = "<group>"; };
 		757800011CCE510A000CD33F /* NSOperationQueue+DKHelper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSOperationQueue+DKHelper.m"; sourceTree = "<group>"; };
 		757800021CCE510A000CD33F /* NSPredicate+DKHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSPredicate+DKHelper.h"; sourceTree = "<group>"; };
@@ -210,6 +212,7 @@
 				7578009B1CCE5917000CD33F /* TestImage.png */,
 				757800741CCE51E8000CD33F /* DKHelper-Bridging-Header.h */,
 				757800581CCE5150000CD33F /* DKViewTest.xib */,
+				3AF99C2F1D65C09600B42C16 /* Localizable.strings */,
 			);
 			path = Resources;
 			sourceTree = "<group>";
@@ -392,6 +395,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				7578009C1CCE5917000CD33F /* TestImage.png in Resources */,
+				3AF99C301D65C09600B42C16 /* Localizable.strings in Resources */,
 				7578006D1CCE5150000CD33F /* DKViewTest.xib in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/DKHelper/DKHelperTests/DKHelperTests.swift
+++ b/DKHelper/DKHelperTests/DKHelperTests.swift
@@ -55,7 +55,13 @@ class DKHelperTests: XCTestCase {
 
 extension DKHelperTests {
 
-	func test_ShouldReturnKeyWhenValueNotFound() {
+	func test_ShouldReturnLocalizedStringWhenKeyExists() {
+		let txt = L("EXISTING_KEY")
+		XCTAssertNotNil(txt)
+		XCTAssertEqual(txt, NSLocalizedString("EXISTING_KEY", comment: ""))
+	}
+
+	func test_ShouldReturnKeyWhenLocalizedStringNotFound() {
 		let txt = L("WELCOME_TEXT_WRONG")
 		XCTAssertNotNil(txt)
 		XCTAssertEqual(txt, "WELCOME_TEXT_WRONG")

--- a/DKHelper/DKHelperTests/Resources/Localizable.strings
+++ b/DKHelper/DKHelperTests/Resources/Localizable.strings
@@ -1,0 +1,9 @@
+/* 
+  Localizable.strings
+  Example
+
+  Created by Hans Seiffert on 18.08.16.
+  Copyright © 2016 Kevin Delord. All rights reserved.
+*/
+
+"EXISTING_KEY" = "VALUE";

--- a/Sources/DKHelper.m
+++ b/Sources/DKHelper.m
@@ -51,7 +51,13 @@ BOOL        VALID_AND_IS_CLASS(NSDictionary *dict, id key, Class classType) {
 #pragma mark - Localization
 
 NSString * _Nonnull L(NSString * _Nonnull key) {
-    return NSLocalizedString(key, nil);
+	static NSString *DEFAULT_STRING = @"+++DKHelper_Unique_Default_String+++";
+	NSString *localizedString = NSLocalizedStringWithDefaultValue(key, nil, [NSBundle mainBundle], DEFAULT_STRING, nil);
+	if ([localizedString isEqualToString:DEFAULT_STRING]) {
+		DKLog(YES, @"Warning: Localized string with key '%@' can't be found!", key);
+		return key;
+	}
+	return localizedString;
 }
 
 #pragma mark - Getters


### PR DESCRIPTION
The L() method is adjusted to print a warning to the console (if the build type is debug) if a localized string can't be found.